### PR TITLE
Fix Carthage dependencies and images in other bundles

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "Exyte/Macaw"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "Exyte/Macaw" "0.9.3"

--- a/Sources/FanMenu.swift
+++ b/Sources/FanMenu.swift
@@ -10,14 +10,14 @@ public enum FanMenuButtonTitlePosition {
 
 public struct FanMenuButton {
     public let id: String
-    public let image: String
+    public let image: UIImage?
     public let color: Color
     public let title: String
     public let titleColor: Color?
     public let titlePosition: FanMenuButtonTitlePosition
     
     public init(id: String,
-                image: String,
+                image: UIImage?,
                 color: Color,
                 title: String = "",
                 titleColor: Color? = .none,
@@ -154,9 +154,9 @@ class FanMenuScene {
         )
         
         buttonNode = [menuCircle].group()
-        if !button.image.isEmpty, let uiImage = UIImage(named: button.image) {
+        if let uiImage = button.image {
             menuIcon = Image(
-                src: button.image,
+                image: uiImage,
                 place: Transform.move(
                     dx: -Double(uiImage.size.width) / 2,
                     dy: -Double(uiImage.size.height) / 2
@@ -262,9 +262,9 @@ class FanMenuScene {
                 fill: button.color
             )
         ]
-        if !button.image.isEmpty, let uiImage = UIImage(named: button.image) {
+        if let uiImage = button.image {
             let image = Image(
-                src: button.image,
+                image: uiImage,
                 place: Transform.move(
                     dx: -Double(uiImage.size.width) / 2,
                     dy: -Double(uiImage.size.height) / 2


### PR DESCRIPTION
### Add explicit dependencies for carthage through Cartfile

This fix issue when adding fan-menu to a project managing dependencies with carthage and not using Macaw yet. It allows carthage to detect Macaw as needed dependency and fixes build error when installing fan-menu.

### Change FanMenuButton’s image string to UIImage

This allows to pass image from different bundle than the main bundle of the App.